### PR TITLE
Rails 8 0 support - fixed instrumenter problem

### DIFF
--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -27,7 +27,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   }
 
   s.add_runtime_dependency("activerecord", ["~> 8.0.0"])
-  s.add_runtime_dependency("ruby-plsql", [">= 0.6.0"])
+  s.add_runtime_dependency("ruby-plsql", [">= 0.8.0"])
   if /java/.match?(RUBY_PLATFORM)
     s.platform = Gem::Platform.new("java")
   else

--- a/activerecord-oracle_enhanced-adapter.gemspec
+++ b/activerecord-oracle_enhanced-adapter.gemspec
@@ -27,7 +27,7 @@ This adapter is superset of original ActiveRecord Oracle adapter.
   }
 
   s.add_runtime_dependency("activerecord", ["~> 8.0.0"])
-  s.add_runtime_dependency("ruby-plsql", [">= 0.8.0"])
+  s.add_runtime_dependency("ruby-plsql", [">= 0.6.0"])
   if /java/.match?(RUBY_PLATFORM)
     s.platform = Gem::Platform.new("java")
   else

--- a/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
@@ -32,7 +32,7 @@ module ActiveRecord
 
       private
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil, async: false, &block)
-          instrumenter.instrument(
+          @instrumenter.instrument(
             "sql.active_record",
             sql:               sql,
             name:              name,

--- a/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
@@ -31,6 +31,10 @@ module ActiveRecord
         end
 
       private
+        def instrumenter # :nodoc:
+          ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] ||= ActiveSupport::Notifications.instrumenter
+        end
+
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil, async: false, &block)
           instrumenter.instrument(
             "sql.active_record",

--- a/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/dbms_output.rb
@@ -32,7 +32,7 @@ module ActiveRecord
 
       private
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil, async: false, &block)
-          @instrumenter.instrument(
+          instrumenter.instrument(
             "sql.active_record",
             sql:               sql,
             name:              name,


### PR DESCRIPTION
Hello,

I've added the missing instrumenter method to the gem and tested it with a running oracle database. Works so far.

